### PR TITLE
Add face avatar gaussian splatting example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# test1
+# Face Avatar Gaussian Splatting Example
+
+This repository contains a simple demonstration of face avatar rendering using 3D Gaussian splatting in pure Python. The implementation does not rely on external packages.
+
+The main script `face_avatar_gaussian_splatting.py` generates a dummy face based on randomly sampled sphere points (as a stand‑in for a 3D morphable model), regresses basic Gaussian parameters from UV coordinates, and renders an image from a specified camera viewpoint. The resulting image is saved to `render.ppm` when the script is executed.
+
+For reference, an alternative version that depends on `numpy` and `matplotlib` is provided in `face_avatar_gaussian_splatting_numpy.py`. This version cannot run in restricted environments without installing additional packages.
+
+## Usage
+
+Run the following command:
+
+```bash
+python3 face_avatar_gaussian_splatting.py
+```
+
+The script outputs `render.ppm` in the current directory and prints a confirmation message.

--- a/face_avatar_gaussian_splatting.py
+++ b/face_avatar_gaussian_splatting.py
@@ -1,0 +1,107 @@
+"""Simple face avatar using 3D Gaussian splatting without external dependencies."""
+
+import math
+import random
+
+# ---- Utility functions ----
+
+def generate_sphere_points(num_points):
+    """Generate points on a unit sphere."""
+    vertices = []
+    for _ in range(num_points):
+        theta = random.uniform(0, 2 * math.pi)
+        phi = random.uniform(0, math.pi)
+        x = math.sin(phi) * math.cos(theta)
+        y = math.sin(phi) * math.sin(theta)
+        z = math.cos(phi)
+        vertices.append((x, y, z))
+    return vertices
+
+
+def uv_map(vertex):
+    x, y, z = vertex
+    u = 0.5 + math.atan2(z, x) / (2 * math.pi)
+    v = 0.5 - math.asin(y) / math.pi
+    return (u, v)
+
+
+def regress_gaussian(uv):
+    u, v = uv
+    r, g, b = u, v, 0.5
+    scale = 0.02 + 0.04 * (u ** 2)
+    opacity = 0.8
+    return (r, g, b, scale, opacity)
+
+
+def project(vertex, camera_pos, look_at, image_size=256, fov=60):
+    cx, cy, cz = camera_pos
+    lx, ly, lz = look_at
+    fx, fy, fz = lx - cx, ly - cy, lz - cz
+    flen = math.sqrt(fx * fx + fy * fy + fz * fz)
+    fx, fy, fz = fx / flen, fy / flen, fz / flen
+    up = (0.0, 1.0, 0.0)
+    rx = fy * up[2] - fz * up[1]
+    ry = fz * up[0] - fx * up[2]
+    rz = fx * up[1] - fy * up[0]
+    rlen = math.sqrt(rx * rx + ry * ry + rz * rz)
+    rx, ry, rz = rx / rlen, ry / rlen, rz / rlen
+    ux = ry * fz - rz * fy
+    uy = rz * fx - rx * fz
+    uz = rx * fy - ry * fx
+    # transform
+    x, y, z = vertex
+    tx = rx * (x - cx) + ry * (y - cy) + rz * (z - cz)
+    ty = ux * (x - cx) + uy * (y - cy) + uz * (z - cz)
+    tz = -(fx * (x - cx) + fy * (y - cy) + fz * (z - cz))
+    f = 1.0 / math.tan(math.radians(fov) / 2)
+    if tz == 0:
+        tz = 1e-6
+    px = f * tx / tz
+    py = f * ty / tz
+    ix = int((px + 1) * image_size / 2)
+    iy = int((1 - py) * image_size / 2)
+    return ix, iy, tz
+
+
+def render(vertices, gaussians, camera_pos, look_at, image_size=256):
+    img = [[[0.0, 0.0, 0.0] for _ in range(image_size)] for _ in range(image_size)]
+    depth = [[1e9 for _ in range(image_size)] for _ in range(image_size)]
+    for v, g in zip(vertices, gaussians):
+        ix, iy, z = project(v, camera_pos, look_at, image_size)
+        if 0 <= ix < image_size and 0 <= iy < image_size:
+            r, g_col, b, scale, opacity = g
+            radius = max(1, int(scale * image_size))
+            for i in range(max(0, iy - radius), min(image_size, iy + radius)):
+                for j in range(max(0, ix - radius), min(image_size, ix + radius)):
+                    d = math.sqrt((i - iy) ** 2 + (j - ix) ** 2)
+                    if d < radius and z < depth[i][j]:
+                        depth[i][j] = z
+                        old = img[i][j]
+                        img[i][j] = [
+                            (1 - opacity) * old[0] + opacity * r,
+                            (1 - opacity) * old[1] + opacity * g_col,
+                            (1 - opacity) * old[2] + opacity * b,
+                        ]
+    return img
+
+
+def save_ppm(image, path):
+    h = len(image)
+    w = len(image[0]) if h > 0 else 0
+    with open(path, 'w') as f:
+        f.write('P3\n{} {}\n255\n'.format(w, h))
+        for row in image:
+            for r, g, b in row:
+                f.write('{} {} {} '.format(int(r * 255), int(g * 255), int(b * 255)))
+            f.write('\n')
+
+
+if __name__ == '__main__':
+    vertices = generate_sphere_points(500)
+    uvs = [uv_map(v) for v in vertices]
+    gaussians = [regress_gaussian(uv) for uv in uvs]
+    camera = (0.0, 0.0, 3.0)
+    look = (0.0, 0.0, 0.0)
+    img = render(vertices, gaussians, camera, look)
+    save_ppm(img, 'render.ppm')
+    print('Rendered image saved to render.ppm')

--- a/face_avatar_gaussian_splatting_numpy.py
+++ b/face_avatar_gaussian_splatting_numpy.py
@@ -1,0 +1,96 @@
+# Basic example of a 3D Gaussian splatting face avatar using dummy data.
+# This script demonstrates how one might regress Gaussian properties from a UV map,
+# position Gaussians with a Morphable Model (placeholder), and render a simple
+# image from a specified camera viewpoint.
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+# Placeholder 3D Morphable Model (3DMM)
+def load_3dmm_geometry(num_points=1000):
+    """Generate dummy 3D face geometry using a sphere as placeholder."""
+    # Sample points on a sphere for simplicity
+    theta = np.random.uniform(0, 2 * np.pi, num_points)
+    phi = np.random.uniform(0, np.pi, num_points)
+    x = np.sin(phi) * np.cos(theta)
+    y = np.sin(phi) * np.sin(theta)
+    z = np.cos(phi)
+    vertices = np.stack([x, y, z], axis=-1)
+    return vertices
+
+def generate_uv_map(vertices):
+    """Dummy UV mapping from 3D sphere points to 2D."""
+    x, y, z = vertices.T
+    u = 0.5 + np.arctan2(z, x) / (2 * np.pi)
+    v = 0.5 - np.arcsin(y) / np.pi
+    return np.stack([u, v], axis=-1)
+
+# Regress Gaussian properties from UV map
+def regress_gaussian_properties(uv):
+    """Given UV coordinates, output 4 gaussian parameters per point.
+    Here we use simple functions as stand-ins for a neural network."""
+    # For demonstration, define mean color from UV and standard deviation
+    color = uv  # using u,v as R,G; B fixed
+    color = np.concatenate([color, np.ones((len(uv), 1)) * 0.5], axis=-1)
+    scale = 0.01 + 0.02 * (uv[:, :1] ** 2)
+    opacity = np.full((len(uv), 1), 0.8)
+    return np.concatenate([color, scale, opacity], axis=-1)
+
+# Camera model
+def project_vertices(vertices, camera_pos, look_at, image_size=256, fov=60):
+    """Simple perspective projection."""
+    # Set up camera axes
+    forward = look_at - camera_pos
+    forward /= np.linalg.norm(forward)
+    up = np.array([0, 1, 0], dtype=np.float32)
+    right = np.cross(forward, up)
+    up = np.cross(right, forward)
+    # Build rotation matrix
+    R = np.stack([right, up, -forward], axis=1)
+    t = -R.T @ camera_pos
+    # Transform vertices
+    transformed = (R.T @ vertices.T).T + t
+    # Perspective
+    f = 1.0 / np.tan(np.radians(fov) / 2)
+    x = f * transformed[:, 0] / (transformed[:, 2] + 1e-6)
+    y = f * transformed[:, 1] / (transformed[:, 2] + 1e-6)
+    img_x = (x + 1) * (image_size / 2)
+    img_y = (1 - y) * (image_size / 2)
+    return np.stack([img_x, img_y, transformed[:,2]], axis=-1)
+
+# Gaussian splatting renderer
+def render_gaussians(projected, gaussians, image_size=256):
+    """Render using simple splatting (additive)"""
+    img = np.zeros((image_size, image_size, 3), dtype=np.float32)
+    depth = np.full((image_size, image_size), 1e9)
+    for (x, y, z), g in zip(projected, gaussians):
+        color = g[:3]
+        scale = g[3]
+        opacity = g[4]
+        radius = int(max(1, scale * image_size))
+        xi = int(round(x))
+        yi = int(round(y))
+        for i in range(max(0, yi - radius), min(image_size, yi + radius)):
+            for j in range(max(0, xi - radius), min(image_size, xi + radius)):
+                d = np.sqrt((i - yi)**2 + (j - xi)**2)
+                if d < radius:
+                    if z < depth[i, j]:
+                        depth[i, j] = z
+                        img[i, j] = (1 - opacity) * img[i, j] + opacity * color
+    return np.clip(img, 0, 1)
+
+if __name__ == "__main__":
+    vertices = load_3dmm_geometry()
+    uv = generate_uv_map(vertices)
+    gaussians = regress_gaussian_properties(uv)
+
+    camera_pos = np.array([0.0, 0.0, 3.0])
+    look_at = np.array([0.0, 0.0, 0.0])
+
+    projected = project_vertices(vertices, camera_pos, look_at)
+    image = render_gaussians(projected, gaussians)
+
+    plt.imshow(image)
+    plt.axis('off')
+    plt.title('Rendered Face Avatar')
+    plt.show()


### PR DESCRIPTION
## Summary
- create `face_avatar_gaussian_splatting.py` with a pure-python implementation of a simple 3D Gaussian splatting face renderer
- include an alternative numpy-based version `face_avatar_gaussian_splatting_numpy.py`
- update README with instructions and description of the example

## Testing
- `python3 face_avatar_gaussian_splatting.py`

------
https://chatgpt.com/codex/tasks/task_e_6847c292ed288328a34bc8caafdba460